### PR TITLE
Fix to BAZINGA! message

### DIFF
--- a/src/xdrip.c
+++ b/src/xdrip.c
@@ -1642,6 +1642,7 @@ void timer_callback_cgm(void *data) {
 	} else {
 		minutes_cgm--;
 		load_cgmtime();
+		load_bg_delta();
 	}
 	APP_LOG(APP_LOG_LEVEL_INFO, "minutes_cgm: %d", minutes_cgm);
 	//APP_LOG(APP_LOG_LEVEL_INFO, "TIMER CALLBACK, SEND CMD DONE, ABOUT TO REGISTER TIMER");


### PR DESCRIPTION
Post removal of the consistent 1 minute poll of xDrip by the pebble, this
message at 5.5 mmol/l, 99 or 100 mg/dl stopped working.
This commit re-instates it.
